### PR TITLE
Remove install of virtualenv

### DIFF
--- a/roles/python3/tasks/install_python3.yml
+++ b/roles/python3/tasks/install_python3.yml
@@ -85,10 +85,3 @@
     mode: "u+rwx,g+rx,o+rx"
   become: yes
   become_user: root
-
-- name: install virtualenv
-  pip:
-    name: virtualenv
-    state: latest
-  become: yes
-  become_user: root


### PR DESCRIPTION
* Python 3 has virtualenv command built in with: python -m venv <name_of_venv>
* https://docs.python.org/3/tutorial/venv.html