### PR TITLE
Add copy of activate_this.py for httpd

### DIFF
--- a/roles/apache/tasks/main.yml
+++ b/roles/apache/tasks/main.yml
@@ -86,3 +86,12 @@
     module_version: 1.0
   become: yes
   become_user: root
+
+- name: copy actiavte_this.py
+  template:
+    src: activate_this.py.j2
+    dest: "{{ multiscanner_venv }}/bin/activate_this.py"
+    mode: 0755
+    owner: "{{ ms_user }}"
+  become: yes
+  become_user: "{{ ms_user }}"

--- a/roles/apache/templates/activate_this.py.j2
+++ b/roles/apache/templates/activate_this.py.j2
@@ -1,0 +1,34 @@
+"""By using execfile(this_file, dict(__file__=this_file)) you will
+activate this virtualenv environment.
+
+This can be used when you must use an existing Python interpreter, not
+the virtualenv bin/python
+"""
+
+try:
+    __file__
+except NameError:
+    raise AssertionError(
+        "You must run this like execfile('path/to/activate_this.py', dict(__file__='path/to/activate_this.py'))")
+import sys
+import os
+
+old_os_path = os.environ.get('PATH', '')
+os.environ['PATH'] = os.path.dirname(os.path.abspath(__file__)) + os.pathsep + old_os_path
+base = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if sys.platform == 'win32':
+    site_packages = os.path.join(base, 'Lib', 'site-packages')
+else:
+    site_packages = os.path.join(base, 'lib', 'python%s' % sys.version[:3], 'site-packages')
+prev_sys_path = list(sys.path)
+import site
+site.addsitedir(site_packages)
+sys.real_prefix = sys.prefix
+sys.prefix = base
+# Move the added items to the front of the path:
+new_sys_path = []
+for item in list(sys.path):
+    if item not in prev_sys_path:
+        new_sys_path.append(item)
+        sys.path.remove(item)
+sys.path[:0] = new_sys_path


### PR DESCRIPTION
activate_this.py was included in virtualenv cmd, but doesn't appear to be in the new python3 -m venv cmd. Adding it manually to allow apache to use it.