### PR TITLE
Remove $1 capture group from CORS header

### DIFF
--- a/roles/ms_restserver/templates/mscan_rest.conf.j2
+++ b/roles/ms_restserver/templates/mscan_rest.conf.j2
@@ -29,7 +29,7 @@
         RewriteEngine On
         RewriteCond %{REQUEST_METHOD} OPTIONS
         RewriteRule ^(.*)$ $1 [R=200,L,ENV=ISOPTIONS:true]
-        SetEnvIf Origin "{{ ms_api_cors_regex }}" AccessControlAllowOrigin=$0$1
+        SetEnvIf Origin "{{ ms_api_cors_regex }}" AccessControlAllowOrigin=$0
         # Set the access-control-origin-allow only on OPTIONS requests; api.py adds the header to everything that gets
         # past the OPTIONS step
         Header always set Access-Control-Allow-Origin %{AccessControlAllowOrigin}e  env=ISOPTIONS


### PR DESCRIPTION
The config file here captures the whole `Origin` request header, and then sends it back as the `Access-Control-Allow-Origin` if it matches the `ms_api_cors_regex` regex. The `$1` here additionally appends the first capture group from the regex, which doesn't appear to do anything meaningful (`$0` already has all of the `Origin` which is already well-formatted as a CORS origin response), and in the worst case can break things. e.g., When the regex is of the form `"http(s)?://..."`, it erroneously appends a trailing `s` to the allowed origin when using HTTPS.