### PR TITLE
Update python3 install

### DIFF
--- a/roles/python3/tasks/install_python3.yml
+++ b/roles/python3/tasks/install_python3.yml
@@ -76,17 +76,6 @@
   become: yes
   become_user: root
 
-- name: set pip 3 to be default pip
-  file:
-    src: "{{ python_install_prefix }}/bin/pip{{ python_version_major_minor }}"
-    dest: "{{ python_install_prefix }}/bin/pip"
-    owner: root
-    group: root
-    state: link
-    mode: "u+rwx,g+rx,o+rx"
-  become: yes
-  become_user: root
-
 - name: install virtualenv
   pip:
     name: virtualenv

--- a/roles/python3/tasks/main.yml
+++ b/roles/python3/tasks/main.yml
@@ -10,5 +10,5 @@
 
 - include: install_python3.yml
   tags: [python]
-  when: "python_version | search(result.stdout)"
+  # when: "python_version | search(result.stdout)"
 


### PR DESCRIPTION
Changes to `get-pip.py` make the symlink unnecessary.